### PR TITLE
Add view fallback config option.

### DIFF
--- a/config/amp.php
+++ b/config/amp.php
@@ -10,6 +10,9 @@ return [
     // (optional)
     'view-bool-name' => 'hasAmpUrl',
 
+    // Use non-amp view if affixed view does not exists.
+    'view-fallback' => false,
+
     'layouts' => [
         'amp::tag'
     ]

--- a/src/Laravel/AmpServiceProvider.php
+++ b/src/Laravel/AmpServiceProvider.php
@@ -52,8 +52,14 @@ class AmpServiceProvider extends ServiceProvider
 
             $finder = $app['view.finder'];
 
-            $env = new AmpViewFactory($resolver, $finder, $app['events'],
-                $app['config']->get('amp.view-affix'), $app['config']->get('amp.view-bool-name'));
+            $env = new AmpViewFactory(
+                $resolver,
+                $finder,
+                $app['events'],
+                $app['config']->get('amp.view-affix'),
+                $app['config']->get('amp.view-bool-name'),
+                $app['config']->get('amp.view-fallback')
+            );
 
             // We will also set the container instance on this view environment since the
             // view composers may be classes registered in the container, which allows


### PR DESCRIPTION
Hi, first of all, thanks for this really nice package - it helps a lot with dealing with AMP pages.

I've started implementing this package where post view has a lot of included sub-views which often already comply with AMP standard. Making copies of those views seems like a waste, so I thought maybe it would be good to have an option where if amp view does not exists, package would load default non-amp view.

For example, say we have a view called `blog.blade.php` internally it includes `post-header.blade.php`.
In order to run this in AMP mode, we would have to created `blog-amp.blade.php` and `post-header-amp.blade.php` views. However,  `post-header.blade.php` is already AMP compliant since it doesn't have any extra styling in it, so if we don't have an amp version of the view, we should try and load default non-amp view.

This PR adds extra config option `view-fallback` which globally sets a flag telling Laravel-Amp to try and load amp-version of the view, but if it does not exist - load originally requested view.